### PR TITLE
remove old php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,38 +17,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 5.6
-      env:
-        - DEPS=latest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 7.0
-      env:
-        - DEPS=lowest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 7.0
-      env:
-        - DEPS=latest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 7.1
-      env:
-        - DEPS=lowest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 7.1
-      env:
-        - DEPS=latest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 7.2
-      env:
-        - DEPS=lowest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
-    - php: 7.2
-      env:
-        - DEPS=latest
-        - EXTMONGODB_DEPS="mongodb/mongodb:~1.4.0"
     - php: 7.3
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
+    "conflict": {
+        "mongodb/mongodb": "<1.6"
+    },
     "support": {
         "issues": "https://github.com/laminas/laminas-cache-storage-adapter-ext-mongodb/issues",
         "forum": "https://discourse.laminas.dev/",

--- a/src/ExtMongoDb.php
+++ b/src/ExtMongoDb.php
@@ -146,7 +146,7 @@ class ExtMongoDb extends AbstractAdapter implements FlushableInterface
                 ));
             }
 
-            if ($result['expires']->sec < (new MongoDate())) {
+            if ($result['expires']->toDateTime() < (new MongoDate())->toDateTime()) {
                 $this->internalRemoveItem($normalizedKey);
                 return;
             }

--- a/src/ExtMongoDb.php
+++ b/src/ExtMongoDb.php
@@ -16,7 +16,9 @@ use MongoDB\BSON\UTCDateTime as MongoDate;
 use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\Exception as MongoDriverException;
+use MongoDB\Model\BSONDocument;
 use stdClass;
+use function property_exists;
 
 /**
  * Cache storage adapter for ext-mongodb
@@ -152,7 +154,7 @@ class ExtMongoDb extends AbstractAdapter implements FlushableInterface
             }
         }
 
-        if (! array_key_exists('value', $result)) {
+        if (! property_exists($result, 'value')) {
             throw new Exception\RuntimeException(sprintf(
                 "The found item _id '%s' for key '%s' is not a valid cache item: missing the field 'value'",
                 (string) $result['_id'],
@@ -280,7 +282,7 @@ class ExtMongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @param string $normalizedKey
      *
-     * @return array|null
+     * @return BSONDocument|null
      *
      * @throws Exception\RuntimeException
      */

--- a/src/ExtMongoDb.php
+++ b/src/ExtMongoDb.php
@@ -223,6 +223,10 @@ class ExtMongoDb extends AbstractAdapter implements FlushableInterface
     public function flush()
     {
         $result = $this->getMongoCollection()->drop();
+        if ($result instanceof stdClass) {
+            $result = (array) $result;
+        }
+
         return ((float) 1) === $result['ok'];
     }
 

--- a/src/ExtMongoDbResourceManager.php
+++ b/src/ExtMongoDbResourceManager.php
@@ -51,8 +51,7 @@ class ExtMongoDbResourceManager
     {
         if ($resource instanceof Collection) {
             $this->resources[$id] = [
-                'db'                  => (string) $resource->db,
-                'db_instance'         => $resource->db,
+                'db'                  => $resource->getDatabaseName(),
                 'collection'          => (string) $resource,
                 'collection_instance' => $resource,
             ];
@@ -88,14 +87,12 @@ class ExtMongoDbResourceManager
         $resource = $this->resources[$id];
         if (! isset($resource['collection_instance'])) {
             try {
-                if (! isset($resource['db_instance'])) {
-                    if (! isset($resource['client_instance'])) {
-                        $resource['client_instance'] = new Client(
-                            isset($resource['server']) ? $resource['server'] : null,
-                            isset($resource['connection_options']) ? $resource['connection_options'] : [],
-                            isset($resource['driver_options']) ? $resource['driver_options'] : []
-                        );
-                    }
+                if (! isset($resource['client_instance'])) {
+                    $resource['client_instance'] = new Client(
+                        isset($resource['server']) ? $resource['server'] : null,
+                        isset($resource['connection_options']) ? $resource['connection_options'] : [],
+                        isset($resource['driver_options']) ? $resource['driver_options'] : []
+                    );
                 }
 
                 $collection = $resource['client_instance']->selectCollection(
@@ -123,7 +120,6 @@ class ExtMongoDbResourceManager
         $this->resources[$id]['server'] = (string) $server;
 
         unset($this->resources[$id]['client_instance']);
-        unset($this->resources[$id]['db_instance']);
         unset($this->resources[$id]['collection_instance']);
     }
 
@@ -151,7 +147,6 @@ class ExtMongoDbResourceManager
         $this->resources[$id]['connection_options'] = $connectionOptions;
 
         unset($this->resources[$id]['client_instance']);
-        unset($this->resources[$id]['db_instance']);
         unset($this->resources[$id]['collection_instance']);
     }
 
@@ -181,7 +176,6 @@ class ExtMongoDbResourceManager
         $this->resources[$id]['driver_options'] = $driverOptions;
 
         unset($this->resources[$id]['client_instance']);
-        unset($this->resources[$id]['db_instance']);
         unset($this->resources[$id]['collection_instance']);
     }
 
@@ -208,7 +202,6 @@ class ExtMongoDbResourceManager
     {
         $this->resources[$id]['db'] = (string) $database;
 
-        unset($this->resources[$id]['db_instance']);
         unset($this->resources[$id]['collection_instance']);
     }
 

--- a/test/unit/ExtMongoDbTest.php
+++ b/test/unit/ExtMongoDbTest.php
@@ -67,4 +67,18 @@ class ExtMongoDbTest extends CommonAdapterTest
 
         $this->assertInstanceOf(ExtMongoDbOptions::class, $this->_storage->getOptions());
     }
+
+    public function testSetItemWithNestedArraysWillReturnNestedArrayValue()
+    {
+        $value = [
+            'foo' => [
+                'bar' => [
+                    'baz' => [],
+                ],
+            ],
+        ];
+
+        $this->assertTrue($this->_storage->setItem('test', $value));
+        $this->assertSame($value, $this->_storage->getItem('test'));
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| QA            | yes

### Description

Remove old PHP versions, mark old `mongodb/mongodb` packages as conflicting and fixed invalid property/array-key access in several files.